### PR TITLE
Fixes for Django 1.5

### DIFF
--- a/subscription/models.py
+++ b/subscription/models.py
@@ -268,7 +268,7 @@ def unsubscribe_expired():
     Loops through all UserSubscription objects with `expires' field
     earlier than datetime.date.today() and forces correct group
     membership."""
-    for us in UserSubscription.objects.get(expires__lt=datetime.date.today()):
+    for us in UserSubscription.objects.filter(expires__lt=datetime.date.today()):
         us.fix()
 
 


### PR DESCRIPTION
- Fix import issues for paypal (been PR'd a couple times already)
- Fix hardcoding of auth.User so that it uses get_user_model() on 1.5
- Fix an obvious typo in a function that would result in an error with more than 1 returned result
